### PR TITLE
Remove blocksize tweaking

### DIFF
--- a/btune/btune.h
+++ b/btune/btune.h
@@ -174,7 +174,6 @@ typedef enum {
     SHUFFLE_SIZE,
     THREADS,
     CLEVEL,
-    BLOCKSIZE,
     MEMCPY,
     WAITING,
     STOP,


### PR DESCRIPTION
Changing blocksize in Blosc2 NDim is not a real option because the blocksize is a critical part of the second partition.  So, I prefer to get rid of the possibility to change it totally.  Please have a look at this and merge it asap.